### PR TITLE
[#97655524] No longer need to specify key / secret when querying AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,14 @@ Read and write gziped content in S3 without hitting disk.
 ```ruby
 require 's3gzip'
 
-id='S3_ACCESS_KEY_ID'
-secret='S3_SECRET_ACCESS_KEY'
-
 bucket='MY_BUCKET'
 filename='a/folder/with/filename.gz'
 
-S3Gzip::Writer.open(id, secret, bucket, filename) do |writer|
+S3Gzip::Writer.open(bucket, filename) do |writer|
   writer.write 'some content, gzipped, then stored in s3.'
 end
 
-result = S3Gzip::Reader.read(id, secret, bucket, filename)
+result = S3Gzip::Reader.read(bucket, filename)
 
 puts result
 # Output:
@@ -32,22 +29,19 @@ You can use `S3Gzip::Writer` in a variety of ways from a one-liner to many-liner
 ```
 require 's3gzip'
 
-id = 'S3_ACCESS_KEY_ID'
-secret = 'S3_SECRET_ACCESS_KEY'
-
 bucket = 'MY_BUCKET'
 filename = 'a/folder/with/filename.gz'
 content = 'some content, gzipped, then stored in s3.'
 
-writer = S3Gzip::Writer.new(id, secret, bucket, filename)
+writer = S3Gzip::Writer.new(bucket, filename)
 writer.write content
 writer.close_and_send
 
-S3Gzip::Writer.open(id, secret, bucket, filename) do |writer|
+S3Gzip::Writer.open(bucket, filename) do |writer|
   writer.write content
 end
 
-S3Gzip::Writer.write(id, secret, bucket, filename, content)
+S3Gzip::Writer.write(bucket, filename, content)
 ``` 
 
 When using the first method, `close_and_send` must be called. This is done automatically when using `open` or `write` class methods. 

--- a/lib/s3gzip/reader.rb
+++ b/lib/s3gzip/reader.rb
@@ -4,11 +4,8 @@ require 's3io'
 
 module S3Gzip
   class Reader
-    def self.read(access_key_id, secret_access_key, bucket, filename)
-      s3 = AWS::S3.new(
-        :access_key_id => access_key_id,
-        :secret_access_key => secret_access_key
-      )
+    def self.read(bucket, filename)
+      s3 = AWS::S3.new
       bucket = s3.buckets[bucket]
       s3_object = bucket.objects[filename]
       io = S3io.open(s3_object, 'r')

--- a/lib/s3gzip/writer.rb
+++ b/lib/s3gzip/writer.rb
@@ -6,17 +6,12 @@ module S3Gzip
     attr_reader :bucket
     attr_reader :filename
 
-    def initialize(access_key_id, secret_access_key, bucket, filename)
+    def initialize(bucket, filename)
 
-      @access_key_id = access_key_id
-      @secret_access_key = secret_access_key
       @bucket = bucket
       @filename = filename
 
-      s3 = AWS::S3.new(
-        :access_key_id => access_key_id,
-        :secret_access_key => secret_access_key
-      )
+      s3 = AWS::S3.new
       bucket = s3.buckets[bucket]
       s3_object = bucket.objects[filename]
       @io = S3io.open(s3_object, 'w')
@@ -46,8 +41,8 @@ module S3Gzip
       writer.close if writer && block_given?
     end
 
-    def self.write(access_key_id, secret_access_key, bucket, filename, value)
-      writer = new(access_key_id, secret_access_key, bucket, filename)
+    def self.write(bucket, filename, value)
+      writer = new(bucket, filename)
       writer.write(value)
       writer.close
     end


### PR DESCRIPTION
This is because the EC2 nodes have AWS auth baked in.
